### PR TITLE
Fix typo in InfoBar.tsx: changed 'coob ha' to 'coop ha'

### DIFF
--- a/src/pages/Home/InfoBar.tsx
+++ b/src/pages/Home/InfoBar.tsx
@@ -46,7 +46,7 @@ function InfoBar() {
 					<span>{new Number(29).toLocaleString('fa-ir')}</span>
 				</div>
 				<div className="space-x-1 space-x-reverse">
-					<span>کوب‌ها</span>
+					<span>کوپ‌ها</span>
 					<span>:</span>
 					<span>{new Number(155).toLocaleString('fa-ir')}</span>
 				</div>


### PR DESCRIPTION
Fix a typo in InfoBar.tsx : changed "coob" to "coop" .

To correct a spelling mistake in the text.

Minor change — no functional impact.